### PR TITLE
PSEC-1472 minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # S3 bucket standard module
 
-This module creates an AWS S3 bucket, KMS key and associated resources while enforcing the PlatSec S3 bucket policy.
-It uses the [core bucket module](https://github.com/hmrc/terraform-aws-s3-bucket-core) which documents the parts of the
-policy that it enforces.
+This module creates an AWS S3 bucket, KMS key and associated resources while enforcing the MDTP PlatSec S3 bucket
+policy. It uses the [core bucket module](https://registry.terraform.io/modules/hmrc/s3-bucket-core/aws/latest) which
+documents the parts of the policy that it enforces.
 
 This module accepts IAM roles and configures access in the bucket and KMS key resource policies to `Allow` access as
 well as `Deny` everyone else. When using this module no additional S3 or KMS permissions are required for access to the
@@ -55,22 +55,23 @@ The security readonly role is not created/managed by this module.
 
 ## Policy enforcement
 
-#### Platform Security meta-data access
+### Platform Security meta-data access
 
 **AWS role RoleSecurityReadOnly has meta-data access to all S3 buckets.** This is for auditing and alerting purposes
 
-#### Logging
+### Logging
 
-Enforced in [core bucket module](https://github.com/hmrc/terraform-aws-s3-bucket-core)
+Enforced in [core bucket module](https://registry.terraform.io/modules/hmrc/s3-bucket-core/aws/latest)
 
-#### Bucket policy
+### Bucket policy
 
 **At all times PlatSec must have access to all AWS S3 metadata (not the data).** See Platform Security meta-data access
 above.
 
 **Secure transport is required.**
 
-**Public access is blocked.** Enforced in [core bucket module](https://github.com/hmrc/terraform-aws-s3-bucket-core)
+**Public access is blocked.**
+Enforced in [core bucket module](https://registry.terraform.io/modules/hmrc/s3-bucket-core/aws/latest)
 
 Additional network level restriction to a fixed known range of IPs or VPCs and locking down access to a set of known IAM
 roles **should** be implemented. This module supports limiting access to specific IP addresses or VPCs.  
@@ -78,16 +79,16 @@ Buckets containing PII **must** implement IP or VPC restrictions.
 **admin_roles and metadata_read_roles are excluded from the IP/VPC restrictions - DO NOT GIVE THESE ROLES READ OR WRITE
 ACCESS TO DATA** 
 
-#### Tagging, Versioning, Life cycle policies, Encryption at rest, Access control list (ACL)
+### Tagging, Versioning, Life cycle policies, Encryption at rest, Access control list (ACL)
 
-See [core bucket module](https://github.com/hmrc/terraform-aws-s3-bucket-core)
+See [core bucket module](https://registry.terraform.io/modules/hmrc/s3-bucket-core/aws/latest)
 
 ## Additional behaviours
 
-#### Ensure the bucket KMS key is used to encrypt objects
+### Ensure the bucket KMS key is used to encrypt objects
 
 This module ensures that the only encryption key that can be use is the KMS key created by the
-[core bucket module](https://github.com/hmrc/terraform-aws-s3-bucket-core).  
+[core bucket module](https://registry.terraform.io/modules/hmrc/s3-bucket-core/aws/latest).  
 To ensure continued access to data, when putting an object either of the following is required
 1. do not specify either `x-amz-server-side-encryption` or `x-amz-server-side-encryption-aws-kms-key-id` so that the 
 bucket server_side_encryption_configuration takes effect

--- a/bucket_policy.tf
+++ b/bucket_policy.tf
@@ -1,6 +1,6 @@
-resource "aws_s3_bucket_policy" "bucket_policy" {
+resource "aws_s3_bucket_policy" "bucket" {
   bucket     = module.bucket.id
-  policy     = data.aws_iam_policy_document.bucket_policy_document.json
+  policy     = data.aws_iam_policy_document.bucket.json
   depends_on = [module.bucket]
 }
 
@@ -11,7 +11,7 @@ resource "aws_s3_bucket_policy" "bucket_policy" {
    NOTE: Any actions added for bucket or object should be also added to the relevant DenyUnknown
    statements.
 */
-data "aws_iam_policy_document" "bucket_policy_document" {
+data "aws_iam_policy_document" "bucket" {
 
   statement {
     sid    = "DenyListBucketContents"

--- a/examples/extra_key/main.tf
+++ b/examples/extra_key/main.tf
@@ -17,7 +17,7 @@ locals {
 
 module "s3_example" {
   source = "../../"
-  #  source      = "hashicorp/hmrc/s3-bucket-standard"
+  #  source      = "hmrc/s3-bucket-standard/aws"
   bucket_name = "${var.test_name}-bucket"
 
   read_roles  = [local.provisioner_role]

--- a/examples/minimal/main.tf
+++ b/examples/minimal/main.tf
@@ -13,7 +13,7 @@ provider "aws" {
 
 module "s3_example" {
   source = "../../"
-  #  source      = "hashicorp/hmrc/s3-bucket-standard"
+  #  source      = "hmrc/s3-bucket-standard/aws"
   bucket_name = "${var.test_name}-bucket"
 
   data_expiry   = "1-day"

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -13,7 +13,7 @@ provider "aws" {
 
 module "s3_example" {
   source = "../../"
-  #  source      = "hashicorp/hmrc/s3-bucket-standard"
+  #  source      = "hmrc/s3-bucket-standard/aws"
   bucket_name = "${var.test_name}-bucket"
   read_roles  = [aws_iam_role.read.arn, data.aws_iam_session_context.current.issuer_arn]
   write_roles = [aws_iam_role.write.arn, data.aws_iam_session_context.current.issuer_arn]

--- a/kms_policy.tf
+++ b/kms_policy.tf
@@ -1,5 +1,5 @@
 
-data "aws_iam_policy_document" "kms_policy" {
+data "aws_iam_policy_document" "kms" {
 
   statement {
     sid    = "DenyAccessToDecrypt"

--- a/main.tf
+++ b/main.tf
@@ -23,13 +23,14 @@ locals {
 }
 
 module "bucket" {
-  source             = "git::https://github.com/hmrc/terraform-aws-s3-bucket-core.git//?ref=0.1.3" # TODO use hashicorp
+  source             = "hmrc/s3-bucket-core/aws"
+  version            = "~> 0.1.4"
   bucket_name        = var.bucket_name
   versioning_enabled = var.versioning_enabled
   data_expiry        = var.data_expiry
   data_sensitivity   = var.data_sensitivity
   force_destroy      = var.force_destroy
-  kms_key_policy     = data.aws_iam_policy_document.kms_policy.json
+  kms_key_policy     = data.aws_iam_policy_document.kms.json
   log_bucket_id      = var.log_bucket_id
   tags               = var.tags
 }

--- a/test/s3_module_acceptance_test.go
+++ b/test/s3_module_acceptance_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
-	"github.com/gruntwork-io/terratest/modules/shell"
 	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
 	"github.com/hmrc/terraform-aws-s3-bucket-standard/test/randomreader"
 	"log"
@@ -346,20 +345,12 @@ func copyTerraformAndReturnOptions(t *testing.T, pathFromRootToSource string, ad
 	for k, v := range additionalVars {
 		vars[k] = v
 	}
-	return CopyTerraformAndReturnOptions(t, pathFromRootToSource, "hashicorp/hmrc/s3-bucket-standard", vars)
+	return CopyTerraformAndReturnOptions(t, pathFromRootToSource, vars)
 }
 
-func CopyTerraformAndReturnOptions(t *testing.T, pathFromRootToSource string, publicModuleSrc string, vars map[string]interface{}) *terraform.Options {
+func CopyTerraformAndReturnOptions(t *testing.T, pathFromRootToSource string, vars map[string]interface{}) *terraform.Options {
 	tempTestFolder := test_structure.CopyTerraformFolderToTemp(t, "..", pathFromRootToSource)
 	log.Print(tempTestFolder)
-
-	publicToLocalModuleExp := `/^module \.*/,/^\}\s*$/ s#\(source\s*=\s*\)"` + publicModuleSrc + `"#\1"../../"#`
-	useLocalModule := shell.Command{
-		Command:    "sed",
-		Args:       []string{"-i", "-e", publicToLocalModuleExp, "main.tf"},
-		WorkingDir: tempTestFolder,
-	}
-	shell.RunCommand(t, useLocalModule)
 
 	return terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: tempTestFolder,


### PR DESCRIPTION
increase size of policy section headings in README
change link to core module from GitHub to TF registry in README
remove code to fixup registry module source reference to local
fixup resource names as they are exposed in the registry UI
