### PR TITLE
BAU sort roles to avoid unnecessary policy changes

### DIFF
--- a/bucket_policy.tf
+++ b/bucket_policy.tf
@@ -53,7 +53,7 @@ data "aws_iam_policy_document" "bucket" {
     condition {
       test     = "StringNotLike"
       variable = "aws:PrincipalArn"
-      values   = distinct(concat(local.readers, local.writers, local.describers))
+      values   = sort(distinct(concat(local.readers, local.writers, local.describers)))
     }
     condition {
       test     = "StringNotEquals"
@@ -371,7 +371,7 @@ data "aws_iam_policy_document" "bucket" {
       condition {
         test     = "StringNotLike"
         variable = "aws:PrincipalArn"
-        values   = distinct(concat(local.admins, local.describers))
+        values   = sort(distinct(concat(local.admins, local.describers)))
       }
       condition {
         test     = "StringNotEquals"
@@ -406,7 +406,7 @@ data "aws_iam_policy_document" "bucket" {
       condition {
         test     = "StringNotLike"
         variable = "aws:PrincipalArn"
-        values   = distinct(concat(local.admins, local.describers))
+        values   = sort(distinct(concat(local.admins, local.describers)))
       }
       condition {
         test     = "StringNotEquals"

--- a/main.tf
+++ b/main.tf
@@ -16,10 +16,10 @@ locals {
   readers = var.read_roles
   writers = var.write_roles
 
-  admins     = distinct(concat(var.admin_roles, [local.current_provisioner_role]))
-  describers = distinct(concat(local.admins, [local.security_audit_role], var.metadata_read_roles))
-  listers    = distinct(concat(local.admins, var.list_roles))
-  all_roles  = distinct(concat(local.admins, local.describers, var.read_roles, var.write_roles, var.list_roles))
+  admins     = sort(distinct(concat(var.admin_roles, [local.current_provisioner_role])))
+  describers = sort(distinct(concat(local.admins, [local.security_audit_role], var.metadata_read_roles)))
+  listers    = sort(distinct(concat(local.admins, var.list_roles)))
+  all_roles  = sort(distinct(concat(local.admins, local.describers, var.read_roles, var.write_roles, var.list_roles)))
 }
 
 module "bucket" {


### PR DESCRIPTION
if an existing role is added to a new input variable, lists of combined
roles can cause the order of the roles to change - sort will prevent
that

this will also avoid unnecessary policy changes when the order of the
roles in the input variables change
