### PR TITLE
Allow metadata access for AWSServiceRoleForAmazonGuardDuty

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -3,4 +3,4 @@ branches: {}
 ignore:
   sha: []
 merge-message-formats: {}
-next-version: 1.6.0
+next-version: 1.7.0

--- a/main.tf
+++ b/main.tf
@@ -10,8 +10,10 @@ terraform {
 }
 
 locals {
-  security_audit_role      = "arn:aws:iam::${data.aws_caller_identity.current.id}:role/RoleSecurityReadOnly"
   current_provisioner_role = data.aws_iam_session_context.current.issuer_arn
+
+  security_audit_role  = var.allow_security_team_metadata_audit ? ["arn:aws:iam::${data.aws_caller_identity.current.id}:role/RoleSecurityReadOnly"] : []
+  guardduty_audit_role = var.allow_guardduty_metadata_audit ? ["arn:aws:iam::${data.aws_caller_identity.current.id}:role/aws-service-role/guardduty.amazonaws.com/AWSServiceRoleForAmazonGuardDuty"] : []
 
   readers = var.read_roles
   writers = var.write_roles
@@ -24,7 +26,7 @@ locals {
 
 
   admins     = sort(distinct(concat(var.admin_roles, [local.current_provisioner_role])))
-  describers = sort(distinct(concat(local.admins, [local.security_audit_role], var.metadata_read_roles)))
+  describers = sort(distinct(concat(local.admins, local.security_audit_role, local.guardduty_audit_role, var.metadata_read_roles)))
   listers    = sort(distinct(concat(local.admins, var.list_roles)))
   all_roles  = sort(distinct(concat(local.admins, local.describers, var.read_roles, var.write_roles, var.list_roles)))
 }

--- a/variables.tf
+++ b/variables.tf
@@ -126,7 +126,7 @@ variable "write_services" {
 
 variable "allow_guardduty_metadata_audit" {
   type        = bool
-  description = "Adds the guraduty service linked role to check metadata of the bucket. This allows it to alert on buckets made public"
+  description = "Adds the AWS GuradDuty service linked role to check metadata of the bucket. This allows it to alert on buckets made public"
   default     = true
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -123,3 +123,15 @@ variable "write_services" {
   description = "A list of AWS Service Principles to allow actions for writing files"
   default     = []
 }
+
+variable "allow_guardduty_metadata_audit" {
+  type        = bool
+  description = "Adds the guraduty service linked role to check metadata of the bucket. This allows it to alert on buckets made public"
+  default     = true
+}
+
+variable "allow_security_team_metadata_audit" {
+  type        = bool
+  description = "Adds the role RoleSecurityReadOnly to check metadata of the bucket. This role is used for manual and automated checks"
+  default     = true
+}


### PR DESCRIPTION
(this can be disabled with `var.allow_guardduty_metadata_audit` set to false)

This is needed as GuardDuty will failsafe and trigger a false positive when checking metadata needed for the alert policy:S3/BucketPublicAccessGranted

To avoid alerts, the following permissions need to be granted:
- GetBucketAcl
- GetBucketTagging
- GetBucketPolicyStatus