### PR TITLE
PSEC-1911

### DIFF
--- a/bucket_policy.tf
+++ b/bucket_policy.tf
@@ -28,12 +28,12 @@ data "aws_iam_policy_document" "bucket" {
       "${module.bucket.arn}/*"
     ]
     condition {
-      test     = "StringNotLike"
+      test     = "ForAnyValue:StringNotLike"
       variable = "aws:PrincipalArn"
       values   = local.listers
     }
     condition {
-      test     = "StringNotLike"
+      test     = "ForAnyValue:StringNotLike"
       variable = "aws:PrincipalServiceName"
       values   = local.list_services
     }
@@ -51,12 +51,12 @@ data "aws_iam_policy_document" "bucket" {
     ]
     resources = [module.bucket.arn]
     condition {
-      test     = "StringNotLike"
+      test     = "ForAnyValue:StringNotLike"
       variable = "aws:PrincipalArn"
       values   = sort(distinct(concat(local.readers, local.writers, local.describers)))
     }
     condition {
-      test     = "StringNotLike"
+      test     = "ForAnyValue:StringNotLike"
       variable = "aws:PrincipalServiceName"
       values   = local.default_services
     }
@@ -74,12 +74,12 @@ data "aws_iam_policy_document" "bucket" {
     ]
     resources = ["${module.bucket.arn}/*"]
     condition {
-      test     = "StringNotLike"
+      test     = "ForAnyValue:StringNotLike"
       variable = "aws:PrincipalArn"
       values   = local.readers
     }
     condition {
-      test     = "StringNotLike"
+      test     = "ForAnyValue:StringNotLike"
       variable = "aws:PrincipalServiceName"
       values   = local.read_services
     }
@@ -99,12 +99,12 @@ data "aws_iam_policy_document" "bucket" {
     ]
     resources = ["${module.bucket.arn}/*"]
     condition {
-      test     = "StringNotLike"
+      test     = "ForAnyValue:StringNotLike"
       variable = "aws:PrincipalArn"
       values   = local.writers
     }
     condition {
-      test     = "StringNotLike"
+      test     = "ForAnyValue:StringNotLike"
       variable = "aws:PrincipalServiceName"
       values   = local.write_services
     }
@@ -129,12 +129,12 @@ data "aws_iam_policy_document" "bucket" {
     ]
     resources = [module.bucket.arn]
     condition {
-      test     = "StringNotLike"
+      test     = "ForAnyValue:StringNotLike"
       variable = "aws:PrincipalArn"
       values   = local.describers
     }
     condition {
-      test     = "StringNotLike"
+      test     = "ForAnyValue:StringNotLike"
       variable = "aws:PrincipalServiceName"
       values   = local.metadata_read_services
     }
@@ -379,13 +379,13 @@ data "aws_iam_policy_document" "bucket" {
         values   = var.restricted_vpce_access
       }
       condition {
-        test     = "StringNotLike"
+        test     = "ForAnyValue:StringNotLike"
         variable = "aws:PrincipalArn"
         values   = sort(distinct(concat(local.admins, local.describers)))
       }
       condition {
-      test     = "StringNotLike"
-      variable = "aws:PrincipalServiceName"
+        test     = "ForAnyValue:StringNotLike"
+        variable = "aws:PrincipalServiceName"
         values   = local.default_services
       }
     }
@@ -414,13 +414,13 @@ data "aws_iam_policy_document" "bucket" {
         values   = var.restricted_ip_access
       }
       condition {
-        test     = "StringNotLike"
+        test     = "ForAnyValue:StringNotLike"
         variable = "aws:PrincipalArn"
         values   = sort(distinct(concat(local.admins, local.describers)))
       }
       condition {
-      test     = "StringNotLike"
-      variable = "aws:PrincipalServiceName"
+        test     = "ForAnyValue:StringNotLike"
+        variable = "aws:PrincipalServiceName"
         values   = local.default_services
       }
     }

--- a/bucket_policy.tf
+++ b/bucket_policy.tf
@@ -33,8 +33,8 @@ data "aws_iam_policy_document" "bucket" {
       values   = local.listers
     }
     condition {
-      test     = "StringNotEquals"
-      variable = "aws:Service"
+      test     = "StringNotLike"
+      variable = "aws:PrincipalServiceName"
       values   = local.list_services
     }
   }
@@ -56,8 +56,8 @@ data "aws_iam_policy_document" "bucket" {
       values   = sort(distinct(concat(local.readers, local.writers, local.describers)))
     }
     condition {
-      test     = "StringNotEquals"
-      variable = "aws:Service"
+      test     = "StringNotLike"
+      variable = "aws:PrincipalServiceName"
       values   = local.default_services
     }
   }
@@ -79,8 +79,8 @@ data "aws_iam_policy_document" "bucket" {
       values   = local.readers
     }
     condition {
-      test     = "StringNotEquals"
-      variable = "aws:Service"
+      test     = "StringNotLike"
+      variable = "aws:PrincipalServiceName"
       values   = local.read_services
     }
   }
@@ -104,8 +104,8 @@ data "aws_iam_policy_document" "bucket" {
       values   = local.writers
     }
     condition {
-      test     = "StringNotEquals"
-      variable = "aws:Service"
+      test     = "StringNotLike"
+      variable = "aws:PrincipalServiceName"
       values   = local.write_services
     }
   }
@@ -134,8 +134,8 @@ data "aws_iam_policy_document" "bucket" {
       values   = local.describers
     }
     condition {
-      test     = "StringNotEquals"
-      variable = "aws:Service"
+      test     = "StringNotLike"
+      variable = "aws:PrincipalServiceName"
       values   = local.metadata_read_services
     }
   }
@@ -384,8 +384,8 @@ data "aws_iam_policy_document" "bucket" {
         values   = sort(distinct(concat(local.admins, local.describers)))
       }
       condition {
-        test     = "StringNotEquals"
-        variable = "aws:Service"
+      test     = "StringNotLike"
+      variable = "aws:PrincipalServiceName"
         values   = local.default_services
       }
     }
@@ -419,8 +419,8 @@ data "aws_iam_policy_document" "bucket" {
         values   = sort(distinct(concat(local.admins, local.describers)))
       }
       condition {
-        test     = "StringNotEquals"
-        variable = "aws:Service"
+      test     = "StringNotLike"
+      variable = "aws:PrincipalServiceName"
         values   = local.default_services
       }
     }

--- a/bucket_policy.tf
+++ b/bucket_policy.tf
@@ -28,12 +28,12 @@ data "aws_iam_policy_document" "bucket" {
       "${module.bucket.arn}/*"
     ]
     condition {
-      test     = "ForAnyValue:StringNotLike"
+      test     = "StringNotLike"
       variable = "aws:PrincipalArn"
       values   = local.listers
     }
     condition {
-      test     = "ForAnyValue:StringNotLike"
+      test     = "StringNotLike"
       variable = "aws:PrincipalServiceName"
       values   = local.list_services
     }
@@ -51,12 +51,12 @@ data "aws_iam_policy_document" "bucket" {
     ]
     resources = [module.bucket.arn]
     condition {
-      test     = "ForAnyValue:StringNotLike"
+      test     = "StringNotLike"
       variable = "aws:PrincipalArn"
       values   = sort(distinct(concat(local.readers, local.writers, local.describers)))
     }
     condition {
-      test     = "ForAnyValue:StringNotLike"
+      test     = "StringNotLike"
       variable = "aws:PrincipalServiceName"
       values   = local.default_services
     }
@@ -74,12 +74,12 @@ data "aws_iam_policy_document" "bucket" {
     ]
     resources = ["${module.bucket.arn}/*"]
     condition {
-      test     = "ForAnyValue:StringNotLike"
+      test     = "StringNotLike"
       variable = "aws:PrincipalArn"
       values   = local.readers
     }
     condition {
-      test     = "ForAnyValue:StringNotLike"
+      test     = "StringNotLike"
       variable = "aws:PrincipalServiceName"
       values   = local.read_services
     }
@@ -99,12 +99,12 @@ data "aws_iam_policy_document" "bucket" {
     ]
     resources = ["${module.bucket.arn}/*"]
     condition {
-      test     = "ForAnyValue:StringNotLike"
+      test     = "StringNotLike"
       variable = "aws:PrincipalArn"
       values   = local.writers
     }
     condition {
-      test     = "ForAnyValue:StringNotLike"
+      test     = "StringNotLike"
       variable = "aws:PrincipalServiceName"
       values   = local.write_services
     }
@@ -129,12 +129,12 @@ data "aws_iam_policy_document" "bucket" {
     ]
     resources = [module.bucket.arn]
     condition {
-      test     = "ForAnyValue:StringNotLike"
+      test     = "StringNotLike"
       variable = "aws:PrincipalArn"
       values   = local.describers
     }
     condition {
-      test     = "ForAnyValue:StringNotLike"
+      test     = "StringNotLike"
       variable = "aws:PrincipalServiceName"
       values   = local.metadata_read_services
     }
@@ -379,13 +379,13 @@ data "aws_iam_policy_document" "bucket" {
         values   = var.restricted_vpce_access
       }
       condition {
-        test     = "ForAnyValue:StringNotLike"
+        test     = "StringNotLike"
         variable = "aws:PrincipalArn"
         values   = sort(distinct(concat(local.admins, local.describers)))
       }
       condition {
-        test     = "ForAnyValue:StringNotLike"
-        variable = "aws:PrincipalServiceName"
+      test     = "StringNotLike"
+      variable = "aws:PrincipalServiceName"
         values   = local.default_services
       }
     }
@@ -414,13 +414,13 @@ data "aws_iam_policy_document" "bucket" {
         values   = var.restricted_ip_access
       }
       condition {
-        test     = "ForAnyValue:StringNotLike"
+        test     = "StringNotLike"
         variable = "aws:PrincipalArn"
         values   = sort(distinct(concat(local.admins, local.describers)))
       }
       condition {
-        test     = "ForAnyValue:StringNotLike"
-        variable = "aws:PrincipalServiceName"
+      test     = "StringNotLike"
+      variable = "aws:PrincipalServiceName"
         values   = local.default_services
       }
     }


### PR DESCRIPTION
Fix bucket policy context key for granting access to services

**Why**
`aws:Service` was not a valid condition context key. S3 bucket policy editor on the console highlighted it as invalid too.
For example, `access-analyzer` service did not have access to the bucket in the screenshot below
![Screenshot 2023-08-10 at 16 09 51](https://github.com/hmrc/terraform-aws-s3-bucket-standard/assets/1915636/c79ac25f-0b57-4b48-aaac-efd2750923b9)

**Test outcome**


```
TestWriteRole 2023-08-10T14:21:25Z logger.go:66:
TestWriteRole 2023-08-10T14:21:25Z logger.go:66: Destroy complete! Resources: 16 destroyed.
PASS
ok      github.com/hmrc/terraform-aws-s3-bucket-standard/test   425.083s

```
