### PR TITLE
PBD-5491 Updating terraform-aws-s3-bucket-core to tag 3.2.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,7 @@ locals {
 }
 
 module "bucket" {
-  source                     = "github.com/hmrc/terraform-aws-s3-bucket-core?ref=3.0.1"
+  source                     = "github.com/hmrc/terraform-aws-s3-bucket-core?ref=3.2.0"
   bucket_name                = var.bucket_name
   versioning_enabled         = var.versioning_enabled
   data_expiry                = var.data_expiry


### PR DESCRIPTION
**Summary**

Updating `terraform-aws-s3-bucket-core` to tag `3.2.0` to get changes in https://github.com/hmrc/terraform-aws-s3-bucket-core/pull/22